### PR TITLE
[issue/45] Fix comment count

### DIFF
--- a/newspage.php
+++ b/newspage.php
@@ -310,7 +310,7 @@ class newspage
 				'EDITED_MESSAGE'		=> $l_edited_by,
 				'EDIT_REASON'			=> $row['post_edit_reason'],
 				'SIGNATURE'				=> ($row['enable_sig']) ? $row['user_sig'] : '',
-				'NEWS_COMMENTS'			=> $this->content_visibility->get_count('topic_posts', $row, $forum_id),
+				'NEWS_COMMENTS'			=> $this->content_visibility->get_count('topic_posts', $row, $forum_id) - 1,
 
 				'POSTER_AVATAR'			=> ($this->user->optionget('viewavatars')) ? get_user_avatar($row['user_avatar'], $row['user_avatar_type'], $row['user_avatar_width'], $row['user_avatar_height']) : '',
 				'U_POST_AUTHOR'			=> get_username_string('profile', $poster_id, $row['username'], $row['user_colour'], $row['post_username']),


### PR DESCRIPTION
The news itself should not be counted as a comment. This was changed with
the soft-delete feature of phpbb.

Fix #45
